### PR TITLE
Switches faces to triangles + create mesh function to send to openGL

### DIFF
--- a/src/clojure/yaw/spec.clj
+++ b/src/clojure/yaw/spec.clj
@@ -11,13 +11,13 @@
 ;; maybe use `keyword?` instead?
 (s/def ::vertices (s/map-of ident? :vector/gen))
 
-(s/def :face/n :vector/norm)
-(s/def :face/v (s/coll-of ident?))
-(s/def ::face (s/keys :req-un [:face/n :face/v]))
+(s/def :tri/n :vector/norm)
+(s/def :tri/v (s/coll-of ident? :count 3))
+(s/def ::tri (s/keys :req-un [:tri/n :tri/v]))
 
-(s/def ::faces (s/map-of ident? ::face))
+(s/def ::tris (s/coll-of ::tri))
 
-(s/def ::geometry (s/keys :req-un [::vertices ::faces]))
+(s/def ::geometry (s/keys :req-un [::vertices ::tris]))
 
 ;; Wrap the geometry in a `mesh` (`object`?) that will also
 ;; hold texture and material info
@@ -38,15 +38,27 @@
 ;;                       :f [1 -1 -1]
 ;;                       :g [-1 -1 -1]
 ;;                       :h [-1 1 -1]}
-;;            :faces {:A {:n [0 0 1]
-;;                        :v [:a :b :c :d]}
-;;                    :B {:n [0 0 -1]
-;;                        :v [:e :f :g :h]}
-;;                    :C {:n [0 1 0]
-;;                        :v [:a :e :h :d]}
-;;                    :D {:n [0 -1 0]
-;;                        :v [:b :f :g :c]}
-;;                    :E {:n [1 0 0]
-;;                        :v [:a :e :f :b]}
-;;                    :F {:n [-1 0 0]
-;;                        :v [:d :c :g :h]}}})
+;;            :tris [{:n [0 0 1]
+;;                    :v [:a :b :c]}
+;;                   {:n [0 0 1]
+;;                    :v [:a :c :d]}
+;;                   {:n [0 0 -1]
+;;                    :v [:e :f :h]}
+;;                   {:n [0 0 -1]
+;;                    :v [:f :g :h]}
+;;                   {:n [0 1 0]
+;;                    :v [:a :e :h]}
+;;                   {:n [0 1 0]
+;;                    :v [:a :h :d]}
+;;                   {:n [0 -1 0]
+;;                    :v [:b :f :c]}
+;;                   {:n [0 -1 0]
+;;                    :v [:f :g :c]}
+;;                   {:n [1 0 0]
+;;                    :v [:a :e :f]}
+;;                   {:n [1 0 0]
+;;                    :v [:a :f :b]}
+;;                   {:n [-1 0 0]
+;;                    :v [:d :c :h]}
+;;                   {:n [-1 0 0]
+;;                    :v [:c :g :h]}]})

--- a/src/clojure/yaw/spec.clj
+++ b/src/clojure/yaw/spec.clj
@@ -24,11 +24,6 @@
 (s/def ::mesh (s/keys :req-un [::geometry]))
 
 ;; Here's how you'd define a cube centered around [0 0 0]
-;; One issue with this is the splitting into triangles.
-;; We don't want to bother the user with triangles
-;;   this allows the abstraction from triangles,
-;;   but then we'd need some way to split a quand into 2 tri,
-;;   and have other splitting methods for other faces too.
 ;; (s/valid? ::geometry
 ;;           {:vertices {:a [1 1 1]
 ;;                       :b [1 -1 1]
@@ -39,26 +34,26 @@
 ;;                       :g [-1 -1 -1]
 ;;                       :h [-1 1 -1]}
 ;;            :tris [{:n [0 0 1]
-;;                    :v [:a :b :c]}
-;;                   {:n [0 0 1]
-;;                    :v [:a :c :d]}
-;;                   {:n [0 0 -1]
-;;                    :v [:e :f :h]}
-;;                   {:n [0 0 -1]
-;;                    :v [:f :g :h]}
-;;                   {:n [0 1 0]
-;;                    :v [:a :e :h]}
-;;                   {:n [0 1 0]
-;;                    :v [:a :h :d]}
-;;                   {:n [0 -1 0]
-;;                    :v [:b :f :c]}
-;;                   {:n [0 -1 0]
-;;                    :v [:f :g :c]}
-;;                   {:n [1 0 0]
-;;                    :v [:a :e :f]}
-;;                   {:n [1 0 0]
-;;                    :v [:a :f :b]}
-;;                   {:n [-1 0 0]
-;;                    :v [:d :c :h]}
-;;                   {:n [-1 0 0]
-;;                    :v [:c :g :h]}]})
+;;                    :v [:a :c :b]}
+;;                    {:n [0 0 1]
+;;                     :v [:a :d :c]}
+;;                    {:n [0 0 -1]
+;;                     :v [:e :f :h]}
+;;                    {:n [0 0 -1]
+;;                     :v [:f :g :h]}
+;;                    {:n [0 1 0]
+;;                     :v [:a :e :h]}
+;;                    {:n [0 1 0]
+;;                     :v [:a :h :d]}
+;;                    {:n [0 -1 0]
+;;                     :v [:b :c :f]}
+;;                    {:n [0 -1 0]
+;;                     :v [:f :c :g]}
+;;                    {:n [1 0 0]
+;;                     :v [:a :f :e]}
+;;                    {:n [1 0 0]
+;;                     :v [:a :b :f]}
+;;                    {:n [-1 0 0]
+;;                     :v [:d :h :c]}
+;;                    {:n [-1 0 0]
+;;                     :v [:c :h :g]}]})

--- a/src/clojure/yaw/world.clj
+++ b/src/clojure/yaw/world.clj
@@ -126,7 +126,8 @@
   (create-item! world :id id
                 :position position
                 :scale scale
-                :mesh (create-simple-mesh! world :rgb color)))
+                :mesh (create-simple-mesh! world :rgb color :texture-name texture)))
+
 
 ;;CAMERA MANAGEMENT------------------------------------------------
 (defn camera "Retrieve the main camera of the world" [world] (.getCamera world))

--- a/src/clojure/yaw/world.clj
+++ b/src/clojure/yaw/world.clj
@@ -24,6 +24,7 @@
 ;;README ONLY USE WORLD IT is A FACADE, no DIRECT USE OF MANAGEMENT/BUILDER TOOLS
 
 ;; Mesh Functions------------------------------------------------
+;; TODO: delete this when `create-simple-mesh` is stable (and we can handle texture)
 
 (defn create-mesh!
   "Create an item in the `world` with the  specified id, position, mesh"
@@ -58,6 +59,50 @@
                (float-array (flat-map normals))
                (int-array (flat-map faces))
                (int weight) (float-array rgb) texture-name))
+
+(defn create-simple-mesh!
+  "Create an item in the `world` from the specified mesh object"
+  [world & {{:keys [vertices tris]
+           :or {vertices {:a [1 1 1]
+                           :b [1 -1 1]
+                           :c [-1 -1 1]
+                           :d [-1 1 1]
+                           :e [1 1 -1]
+                           :f [1 -1 -1]
+                           :g [-1 -1 -1]
+                           :h [-1 1 -1]}
+                tris [{:n [0 0 1]
+                        :v [:a :c :b]}
+                       {:n [0 0 1]
+                        :v [:a :d :c]}
+                       {:n [0 0 -1]
+                        :v [:e :f :h]}
+                       {:n [0 0 -1]
+                        :v [:f :g :h]}
+                       {:n [0 1 0]
+                        :v [:a :e :h]}
+                       {:n [0 1 0]
+                        :v [:a :h :d]}
+                       {:n [0 -1 0]
+                        :v [:b :c :f]}
+                       {:n [0 -1 0]
+                        :v [:f :c :g]}
+                       {:n [1 0 0]
+                        :v [:a :f :e]}
+                       {:n [1 0 0]
+                        :v [:a :b :f]}
+                       {:n [-1 0 0]
+                        :v [:d :h :c]}
+                       {:n [-1 0 0]
+                        :v [:c :h :g]}]}}
+            :geometry
+            rgb :rgb}]
+  (let [vidx (zipmap (keys vertices) (range (count vertices)))
+        coords (float-array (mapcat second vertices))
+        normals (float-array (mapcat (fn [{n :n v :v}] (concat n n n)) tris))
+        indices (int-array (mapcat (fn [{n :n v :v}] (map #(% vidx) v)) tris))]
+    (.createMesh world coords normals indices (float-array rgb))))
+
 ;; Items Functions------------------------------------------------
 (defn create-item!
   "Create an item in the `world` with the
@@ -81,11 +126,10 @@
   (create-item! world :id id
                 :position position
                 :scale scale
-                :mesh (create-mesh! world :rgb color :texture-name texture)))
+                :mesh (create-simple-mesh! world :rgb color)))
 
 ;;CAMERA MANAGEMENT------------------------------------------------
 (defn camera "Retrieve the main camera of the world" [world] (.getCamera world))
-
 
 ;; Collision
 

--- a/src/java/yaw/engine/World.java
+++ b/src/java/yaw/engine/World.java
@@ -147,6 +147,28 @@ public class World implements Runnable {
     }
 
     /**
+     * Create a mesh with the specified parameters
+     * Mesh won't be load into the grahpic cards unless you bind it to an item
+     *
+     * @param pVertices    vetices
+     * @param pNormals     normals
+     * @param pIndices     indices
+     * @return the mesh
+     */
+    public Mesh createMesh(float[] pVertices, float[] pNormals, int[] pIndices, float[] rgb) {
+        if (rgb.length != 3) {
+        throw new RuntimeException("RGB must represent 3 colors");
+    }
+        Vector3f lMaterialColor = new Vector3f(rgb[0], rgb[1], rgb[2]);
+        Material lMaterial = mNucleus.createMaterial(lMaterialColor);
+        Mesh lMesh = mNucleus.createMesh(pVertices, pNormals, pIndices);
+        lMesh.setMaterial(lMaterial);
+        return lMesh;
+    }
+
+
+
+    /**
      * Create a bounding box with the specified parameters and add it to the  world
      *
      * @param id        id

--- a/src/java/yaw/engine/WorldNucleus.java
+++ b/src/java/yaw/engine/WorldNucleus.java
@@ -62,6 +62,12 @@ public class WorldNucleus {
         return lMesh;
     }
 
+    public Mesh createMesh(float[] pVertices, float[] pNormals, int[]pIndices) {
+        Mesh lMesh = new Mesh(pVertices, pNormals, pIndices);
+        lMesh.setDrawingStrategy(new DefaultDrawingStrategy());
+        return lMesh;
+    }
+
     public Item createItem(Item pItem) {
         return new Item(pItem);
     }

--- a/src/java/yaw/engine/meshs/Mesh.java
+++ b/src/java/yaw/engine/meshs/Mesh.java
@@ -53,6 +53,17 @@ public class Mesh {
     }
 
     /**
+     * Construct a Mesh with the specified mVertices, mNormals and mIndices.
+     *
+     * @param pVertices   Vertex array
+     * @param pNormals    Normal vectors
+     * @param pIndices    Triangles
+     */
+    public Mesh(float[] pVertices, float[] pNormals, int[] pIndices) {
+        this(pVertices, null, pNormals, pIndices, pVertices.length);
+    }
+
+    /**
      * Construct a Mesh with the specified  mVertices, mNormals, mIndices , mTextureCoordinate and mWeight
      *
      * @param pVertices   Vertex array


### PR DESCRIPTION
Had to touch a bit some java overloaded methods to allow for not having to instantiate arrays on the clojure side.

I had a bit of hard time debugging the display because I thought something was wrong with my normal array construction (drawing was totally off).
Turns out the order of the vertices in the triangles **is** defining the normals (which makes me wonder how needed our holding of the normal data is)

Readme snippet is still working, but now uses the new mesh functions

TODO: factorize some code in separate namespaces for higher-order structures like blocks, spheres, cones, and such. and conversion functions to low-level mesh structure.